### PR TITLE
Add zoom controls to map and adds initial zoom and center coordinates

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,7 @@
 <body>
   <div id="map">
   </div>
-      <!--  the a tag below can link you to another HTML page  -->
-      <!--  if you click the button in the browser right now, you'll get an error because that is not a real file path -->
-      <a href="<file path"><button class="default-button">GO TO OTHER PAGE</button></a>
-    <script
+  <script
     src='https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js'>
   </script>
   <script src="main.bundle.js"></script>

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,5 +4,9 @@ var mapboxgl = require('mapbox-gl/dist/mapbox-gl.js');
 mapboxgl.accessToken = 'pk.eyJ1IjoianBsYW8iLCJhIjoiY2p1NHE2emUzMGdicTQ0bzJwdW91aGZ1MCJ9.xOcYJbcXocOi1wogWwWv6w';
 var map = new mapboxgl.Map({
 container: 'map',
-style: 'mapbox://styles/mapbox/streets-v11'
+style: 'mapbox://styles/mapbox/streets-v11',
+center: [-105.27, 40],
+zoom: 1.5
 });
+
+map.addControl(new mapboxgl.NavigationControl());


### PR DESCRIPTION
#### Pivotal URL or Waffle Card number: closes #1, closes #2, closes #3 

#### What does this PR do?
Adds controls for zoom to map
Centers map by adding initial coordinates and zoom

#### Where should the reviewer start?
zoom controls are added in line 12 of lib/index.js
coordinates and initial zoom are set in lines 8 and 9

#### Any additional context you want to provide?

#### Screenshots (if appropriate)
